### PR TITLE
feat: replace category dropdown with shadcn Badge components

### DIFF
--- a/apps/blog/src/pages/about.astro
+++ b/apps/blog/src/pages/about.astro
@@ -53,7 +53,7 @@ import Layout from '../layouts/Layout.astro';
         <a href="https://x.com/vandotorres" target="_blank" rel="noopener"
           >Twitter</a
         >
-        <a href="mailto:servando@example.com">Email</a>
+        <a href="mailto:servando@controlthrive.com">Email</a>
       </div>
     </div>
   </article>

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -2,7 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 ---
 
-<Layout title="Servando's Blog - AI, ML, and Technology Insights">
+<Layout title="Servando's Blog - Writing, Learning, and Sharing Knowledge">
   <section class="text-center py-20">
     <h1 class="text-3xl md:text-4xl font-bold mb-6">Hi, I'm Servando</h1>
     <p class="text-xl max-w-2xl mx-auto leading-relaxed mb-12">

--- a/apps/blog/src/pages/index.astro
+++ b/apps/blog/src/pages/index.astro
@@ -4,10 +4,9 @@ import Layout from '../layouts/Layout.astro';
 
 <Layout title="Servando's Blog - AI, ML, and Technology Insights">
   <section class="text-center py-20">
-    <h1 class="text-5xl md:text-6xl font-bold mb-6">Hi, I'm Servando 👋</h1>
+    <h1 class="text-3xl md:text-4xl font-bold mb-6">Hi, I'm Servando</h1>
     <p class="text-xl max-w-2xl mx-auto leading-relaxed mb-12">
-      I write about AI, machine learning, and technology. Welcome to my digital
-      garden where I share insights, experiments, and learnings.
+      Big part of my life, I've been writing on paper—preferably Moleskines. I figured blogging is a good way to leave a legacy. I consider myself a generalist learning from domain experts.
     </p>
 
     <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">

--- a/apps/blog/src/pages/posts/index.astro
+++ b/apps/blog/src/pages/posts/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../../layouts/Layout.astro';
 import { getAllPosts, getAllCategories } from '../../utils/posts';
 import { formatDate } from '../../utils/dates';
+import Badge from '@website-blog/ui/components/Badge.astro';
 
 const posts = await getAllPosts();
 const categories = await getAllCategories();
@@ -22,14 +23,26 @@ const categories = await getAllCategories();
         class="search-input"
       />
 
-      <select id="category-filter" class="category-filter">
-        <option value="">All Categories</option>
+      <div class="category-badges">
+        <Badge 
+          variant="outline" 
+          class="category-badge active" 
+          data-category=""
+        >
+          All Categories
+        </Badge>
         {
           categories.map(category => (
-            <option value={category}>{category}</option>
+            <Badge 
+              variant="outline" 
+              class="category-badge" 
+              data-category={category}
+            >
+              {category}
+            </Badge>
           ))
         }
-      </select>
+      </div>
     </div>
 
     <div class="post-list" id="post-list">
@@ -76,29 +89,41 @@ const categories = await getAllCategories();
     flex-wrap: wrap;
   }
 
-  .search-input,
-  .category-filter {
+  .search-input {
     padding: 0.75rem;
     border: 1px solid var(--border);
     border-radius: 0.5rem;
     background-color: var(--bg-secondary);
     color: var(--text-primary);
     font-size: 1rem;
-  }
-
-  .search-input {
     flex: 1;
     min-width: 300px;
   }
 
-  .category-filter {
-    min-width: 200px;
-  }
-
-  .search-input:focus,
-  .category-filter:focus {
+  .search-input:focus {
     outline: none;
     border-color: var(--accent);
+  }
+
+  .category-badges {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+
+  .category-badge {
+    transition: all 0.2s ease;
+  }
+
+  .category-badge:hover {
+    transform: translateY(-1px);
+  }
+
+  .category-badge.active {
+    background-color: hsl(var(--primary));
+    color: hsl(var(--primary-foreground));
+    border-color: hsl(var(--primary));
   }
 
   .category {
@@ -133,6 +158,10 @@ const categories = await getAllCategories();
     .search-input {
       min-width: unset;
     }
+
+    .category-badges {
+      justify-content: flex-start;
+    }
   }
 </style>
 
@@ -141,16 +170,26 @@ const categories = await getAllCategories();
     const searchInput = document.getElementById(
       'search-input'
     ) as HTMLInputElement;
-    const categoryFilter = document.getElementById(
-      'category-filter'
-    ) as HTMLSelectElement;
     const postList = document.getElementById('post-list')!;
     const noPostsMessage = document.getElementById('no-posts')!;
     const posts = postList.querySelectorAll('.post-card');
+    const categoryBadges = document.querySelectorAll('.category-badge');
+    
+    let selectedCategory = '';
+
+    function updateBadgeStates() {
+      categoryBadges.forEach(badge => {
+        const badgeCategory = badge.getAttribute('data-category') || '';
+        if (badgeCategory === selectedCategory) {
+          badge.classList.add('active');
+        } else {
+          badge.classList.remove('active');
+        }
+      });
+    }
 
     function filterPosts() {
       const searchTerm = searchInput.value.toLowerCase();
-      const selectedCategory = categoryFilter.value;
       let visibleCount = 0;
 
       posts.forEach(post => {
@@ -175,22 +214,32 @@ const categories = await getAllCategories();
       });
 
       noPostsMessage.style.display = visibleCount === 0 ? 'block' : 'none';
+      updateBadgeStates();
     }
 
     // Add event listeners
     searchInput.addEventListener('input', filterPosts);
-    categoryFilter.addEventListener('change', filterPosts);
 
-    // Category button clicks
+    // Category badge clicks
     document.addEventListener('click', e => {
       const target = e.target as HTMLElement;
+      if (target.classList.contains('category-badge')) {
+        const category = target.getAttribute('data-category') || '';
+        selectedCategory = category;
+        filterPosts();
+      }
+      
+      // Handle individual post category clicks
       if (target.classList.contains('category')) {
         const category = target.getAttribute('data-category');
         if (category) {
-          categoryFilter.value = category;
+          selectedCategory = category;
           filterPosts();
         }
       }
     });
+
+    // Initialize
+    filterPosts();
   });
 </script>

--- a/packages/ui/components/Badge.astro
+++ b/packages/ui/components/Badge.astro
@@ -1,0 +1,33 @@
+---
+import { cn } from '../utils';
+
+export interface Props {
+  variant?: 'default' | 'secondary' | 'destructive' | 'outline';
+  class?: string;
+  onClick?: string;
+  'data-category'?: string;
+}
+
+const { variant = 'default', class: className, onClick, 'data-category': dataCategory, ...props } = Astro.props;
+
+const badgeClasses = cn(
+  // Base styles
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors cursor-pointer select-none",
+  // Variant styles
+  {
+    'border-transparent bg-black dark:bg-white text-white dark:text-black hover:bg-black/80 dark:hover:bg-white/80': variant === 'default',
+    'border-transparent bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 hover:bg-gray-200 dark:hover:bg-gray-700': variant === 'secondary',
+    'border-transparent bg-red-500 text-white hover:bg-red-600': variant === 'destructive',
+    'border-gray-300 dark:border-gray-600 bg-transparent text-gray-900 dark:text-gray-100 hover:bg-gray-100 dark:hover:bg-gray-800': variant === 'outline',
+  }[variant],
+  className
+);
+---
+
+<button 
+  class={badgeClasses} 
+  data-category={dataCategory}
+  {...props}
+>
+  <slot />
+</button>

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,6 +1,9 @@
 // Export shared utilities and types
 export * from './utils';
 
+// Export UI components
+export { Badge } from './components/Badge';
+
 // Export theme configuration
 export { themeConfig } from './theme';
 

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,11 +1,11 @@
 // Export shared utilities and types
 export * from './utils';
 
-// Export UI components
-export { Badge } from './components/Badge';
-
 // Export theme configuration
 export { themeConfig } from './theme';
 
 // Export content cross-referencing system
 export * from './content-links';
+
+// Note: Badge.astro component is available via direct import:
+// import Badge from '@website-blog/ui/components/Badge.astro';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,12 +16,10 @@
     "tailwind-merge": "^2.2.0"
   },
   "peerDependencies": {
-    "react": "^18.0.0",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "typescript": "^5.8.3",
-    "@types/react": "^18.0.0"
+    "typescript": "^5.8.3"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -6,14 +6,22 @@
   "main": "./index.ts",
   "exports": {
     ".": "./index.ts",
+    "./components/Badge.astro": "./components/Badge.astro",
     "./styles/index.css": "./styles/index.css",
     "./tailwind": "./tailwind.config.js"
   },
+  "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "tailwind-merge": "^2.2.0"
+  },
   "peerDependencies": {
+    "react": "^18.0.0",
     "tailwindcss": "^3.4.17",
     "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@types/react": "^18.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Replace dropdown category filter with aesthetic shadcn Badge components  
- Update blog main page title and personal description text
- Implement interactive filtering with visual active states and hover effects

## Key Changes
- **New shadcn Badge component** added to shared UI package with multiple variants (default, secondary, destructive, outline)
- **Modern category interface** - users can now click beautiful badge buttons instead of using a dropdown
- **Enhanced UX** with active state highlighting and smooth hover animations
- **Updated blog homepage** with smaller title and new personal description about writing legacy
- **Maintained functionality** - search and filtering work exactly as before

## Technical Details
- Added `Badge.astro` component with proper TypeScript support
- Updated package exports to include the new component
- Replaced dropdown `<select>` with flex grid of clickable badges
- Enhanced JavaScript for badge-based filtering with visual feedback
- Responsive design that works on all screen sizes

## Test Plan
- ✅ Blog builds successfully without errors
- ✅ Categories display as interactive badges
- ✅ Filtering functionality works with badge clicks
- ✅ Search input continues to work alongside badge filtering
- ✅ Active states provide proper visual feedback
- ✅ Responsive design maintains usability on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)