### PR TITLE
feat(website): add /pa-os one-screen hook page + OG card

### DIFF
--- a/apps/website/src/components/Header.astro
+++ b/apps/website/src/components/Header.astro
@@ -4,6 +4,7 @@ import { bookingUrl } from '../lib/siteContent';
 const pathname = Astro.url.pathname;
 
 const links = [
+  { href: '/pa-os', label: 'PA-OS' },
   { href: '/case-studies', label: 'Case studies' },
   { href: '/#product', label: 'Product' },
   { href: '/blog', label: 'Writing' },

--- a/apps/website/src/pages/api/og/pa-os.png.ts
+++ b/apps/website/src/pages/api/og/pa-os.png.ts
@@ -1,0 +1,227 @@
+import type { APIRoute } from 'astro';
+import { ImageResponse } from '@vercel/og';
+
+type Style = Record<string, string | number>;
+
+const colors = {
+  paper: '#F6F4EE',
+  ink: '#141612',
+  muted: '#687064',
+  line: '#D8D3C6',
+  olive: '#6F8052',
+};
+
+function node(type: string, style: Style, children?: unknown) {
+  return {
+    type,
+    props: { style, children },
+  };
+}
+
+const div = (style: Style, children?: unknown) => node('div', style, children);
+const span = (style: Style, children?: unknown) => node('span', style, children);
+
+const pillars = ['Source', 'Standardize', 'Match', 'Campaigns', 'Report'];
+const activePillar = 2;
+
+// One pillar in the rail: a dot over a label; the active one is olive.
+const pillarNode = (label: string, active: boolean) =>
+  div(
+    {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
+      gap: '14px',
+      width: '132px',
+    },
+    [
+      div({
+        width: active ? '16px' : '13px',
+        height: active ? '16px' : '13px',
+        borderRadius: '999px',
+        background: active ? colors.olive : colors.paper,
+        border: `1.5px solid ${active ? colors.olive : colors.muted}`,
+      }),
+      div(
+        {
+          fontFamily: '"Geist Mono", monospace',
+          fontSize: '17px',
+          letterSpacing: '0.04em',
+          color: active ? colors.ink : colors.muted,
+        },
+        label
+      ),
+    ]
+  );
+
+export const GET: APIRoute = async () => {
+  return new ImageResponse(
+    div(
+      {
+        position: 'relative',
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        background: colors.paper,
+        color: colors.ink,
+        overflow: 'hidden',
+        fontFamily: '"Geist", "Segoe UI", sans-serif',
+      },
+      [
+        // frame hairlines
+        div({
+          position: 'absolute',
+          left: '72px',
+          right: '72px',
+          top: '72px',
+          height: '1px',
+          background: colors.line,
+        }),
+        div({
+          position: 'absolute',
+          left: '72px',
+          right: '72px',
+          bottom: '72px',
+          height: '1px',
+          background: colors.line,
+        }),
+        div({
+          position: 'absolute',
+          right: '72px',
+          top: '72px',
+          width: '1px',
+          height: '486px',
+          background: colors.line,
+        }),
+
+        // brand
+        div(
+          {
+            position: 'absolute',
+            left: '72px',
+            top: '42px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '14px',
+          },
+          [
+            div(
+              {
+                width: '38px',
+                height: '38px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                border: `1px solid ${colors.ink}`,
+                color: colors.ink,
+                fontSize: '14px',
+                fontWeight: 600,
+                lineHeight: 1,
+              },
+              'CT'
+            ),
+            div(
+              { fontSize: '26px', fontWeight: 500, lineHeight: 1 },
+              'controlthrive'
+            ),
+          ]
+        ),
+
+        // eyebrow + headline + sub
+        div(
+          {
+            position: 'absolute',
+            left: '132px',
+            top: '150px',
+            width: '900px',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '26px',
+          },
+          [
+            div(
+              {
+                display: 'flex',
+                alignItems: 'center',
+                gap: '12px',
+                color: colors.olive,
+                fontFamily: '"Geist Mono", monospace',
+                fontSize: '20px',
+                letterSpacing: '0.1em',
+              },
+              [
+                div({
+                  width: '9px',
+                  height: '9px',
+                  borderRadius: '999px',
+                  background: colors.olive,
+                }),
+                div({}, 'PA-OS · CLOSED BETA'),
+              ]
+            ),
+            div(
+              {
+                display: 'flex',
+                flexDirection: 'column',
+                fontSize: '76px',
+                lineHeight: 0.98,
+                fontWeight: 600,
+                letterSpacing: '-0.02em',
+              },
+              [
+                span({}, 'The operating system'),
+                span({}, 'for placement agents.'),
+              ]
+            ),
+            div(
+              {
+                width: '660px',
+                color: colors.muted,
+                fontSize: '27px',
+                lineHeight: 1.34,
+                fontWeight: 400,
+              },
+              'One agent runs the whole raise — every claim cited, nothing sent without your review.'
+            ),
+          ]
+        ),
+
+        // pillar rail
+        div(
+          {
+            position: 'absolute',
+            left: '128px',
+            bottom: '104px',
+            display: 'flex',
+            alignItems: 'flex-start',
+          },
+          pillars.map((p, i) => pillarNode(p, i === activePillar))
+        ),
+
+        // url
+        div(
+          {
+            position: 'absolute',
+            right: '104px',
+            bottom: '96px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+            color: colors.olive,
+            fontSize: '18px',
+            fontWeight: 500,
+            lineHeight: 1,
+          },
+          [
+            div({ width: '28px', height: '2px', background: colors.olive }),
+            div({}, 'controlthrive.com/pa-os'),
+          ]
+        ),
+      ]
+    ) as any,
+    {
+      width: 1200,
+      height: 630,
+    }
+  );
+};

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -79,8 +79,6 @@ const latestPosts = blogPostModules
   )
   .slice(0, 3);
 
-const requestAccess = 'mailto:servando@controlthrive.com?subject=PA-OS%20access';
-
 const productProofs = [
   {
     title: 'Import that never asks twice.',
@@ -264,7 +262,7 @@ const productProofs = [
               whichever broker-dealer you're on.
             </p>
             <div class="product__actions">
-              <a class="btn-ink" href={requestAccess}>Request access</a>
+              <a class="btn-ink" href={bookingUrl} target="_blank" rel="noopener noreferrer">Request access</a>
               <a class="link-quiet" href="/pa-os">See PA-OS</a>
             </div>
           </div>

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -265,6 +265,7 @@ const productProofs = [
             </p>
             <div class="product__actions">
               <a class="btn-ink" href={requestAccess}>Request access</a>
+              <a class="link-quiet" href="/pa-os">See PA-OS</a>
             </div>
           </div>
 

--- a/apps/website/src/pages/pa-os.astro
+++ b/apps/website/src/pages/pa-os.astro
@@ -1,8 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import Glyph from '../components/Glyph.astro';
-
-const requestAccess = 'mailto:servando@controlthrive.com?subject=PA-OS%20access';
+import { bookingUrl } from '../lib/siteContent';
 
 // The five pillars of a raise, each an agent taking one action under the same
 // cited, human-approved contract. Rail labels stay short; the focus tile shows
@@ -123,7 +122,7 @@ const initial = pillars[start];
     </section>
 
     <div class="cta">
-      <a class="btn-ink" href={requestAccess}>Request access</a>
+      <a class="btn-ink" href={bookingUrl} target="_blank" rel="noopener noreferrer">Request access</a>
       <span class="cta__note">closed beta · for placement agents &amp; independent bankers</span>
     </div>
   </main>

--- a/apps/website/src/pages/pa-os.astro
+++ b/apps/website/src/pages/pa-os.astro
@@ -9,7 +9,10 @@ import { bookingUrl } from '../lib/siteContent';
 const svg = (paths: string) =>
   `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
 
-const extIcon = svg('<path d="M9 3.5h3.5V7"/><path d="M12.5 3.5 7.5 8.5"/><path d="M11 9.5v3H3.5V5H6.5"/>');
+// Explicit width/height so it stays small even when injected by JS (which
+// creates elements without Astro's scoped-style attribute).
+const extIcon =
+  '<svg viewBox="0 0 16 16" width="11" height="11" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M9 3.5h3.5V7"/><path d="M12.5 3.5 7.5 8.5"/><path d="M11 9.5v3H3.5V5H6.5"/></svg>';
 
 // Each pillar mirrors the real product panel: a header with counts + an
 // "Open …" link, an optional evidence note, and hairline rows that each carry a
@@ -591,8 +594,10 @@ const initial = pillars[start];
     .os__ext {
       display: inline-flex;
       color: var(--ink-3);
+      flex: none;
     }
-    .os__ext :global(svg) {
+    /* Fully global so it also matches JS-injected rows (which lack the scope attr). */
+    :global(.os__ext svg) {
       width: 11px;
       height: 11px;
       display: block;

--- a/apps/website/src/pages/pa-os.astro
+++ b/apps/website/src/pages/pa-os.astro
@@ -93,7 +93,7 @@ const initial = pillars[start];
 
 <Layout
   title="PA-OS — the operating system for placement agents"
-  description="PA-OS runs the whole raise on one agent: search, standardization, matching, campaigns, and reporting — every claim cited, nothing sent without your review. Closed beta."
+  description="PA-OS runs the whole raise on one agent: search, standardization, matching, campaigns, and reporting — every claim cited back to its source. Closed beta."
   ogImage="/api/og/pa-os.png"
   ogImageAlt="PA-OS — the operating system for placement agents: source, standardize, match, campaigns, report."
 >
@@ -109,7 +109,7 @@ const initial = pillars[start];
       <p class="lede">
         Search, standardization, matching, campaigns, and reporting — one agent,
         one chat, on top of the CRM you already use. Every claim carries a
-        receipt, and nothing sends itself.
+        receipt back to its source.
       </p>
     </section>
 
@@ -168,8 +168,6 @@ const initial = pillars[start];
           ))}
         </ul>
       </article>
-
-      <p class="os__foot">nothing ships without human review</p>
     </section>
 
     <div class="cta">
@@ -676,15 +674,6 @@ const initial = pillars[start];
     .os__status--in .os__statustick {
       color: var(--live);
     }
-    .os__foot {
-      text-align: center;
-      font-family: var(--font-mono);
-      font-size: 0.6875rem;
-      letter-spacing: 0.04em;
-      color: var(--ink-3);
-      margin: 0;
-    }
-
     .cta {
       display: flex;
       align-items: center;

--- a/apps/website/src/pages/pa-os.astro
+++ b/apps/website/src/pages/pa-os.astro
@@ -1,0 +1,398 @@
+---
+import Layout from '../layouts/Layout.astro';
+import Glyph from '../components/Glyph.astro';
+
+const requestAccess = 'mailto:servando@controlthrive.com?subject=PA-OS%20access';
+
+// The five pillars of a raise, each an agent taking one action under the same
+// cited, human-approved contract. Rail labels stay short; the focus tile shows
+// the full receipt. Copy shared with the homepage vignette.
+const pillars = [
+  {
+    label: 'Source',
+    kind: 'Sourcing',
+    receipt: 'cited',
+    claim: 'Found 14 new investors for the Meridian mandate.',
+    evidence: 'deduped against your book · sources attached',
+    logged: '✓ Added to mandate — decision logged',
+  },
+  {
+    label: 'Standardize',
+    kind: 'Standardization',
+    receipt: 'sourced',
+    claim: 'Turned the pitch deck into a typed, provenance-quoted mandate.',
+    evidence: 'deck p.4 — “seeking €40 million in commitments”',
+    logged: '✓ Mandate created — decision logged',
+  },
+  {
+    label: 'Match',
+    kind: 'Matching',
+    receipt: 'cited',
+    claim: 'Ranked 60 investors — who to approach, in what order, and why.',
+    evidence: 'each rank cited · do-not-contact enforced',
+    logged: '✓ Target list saved — decision logged',
+  },
+  {
+    label: 'Campaigns',
+    kind: 'Campaigns',
+    receipt: 'for review',
+    claim: 'Drafted 38 outreach emails from the record.',
+    evidence: 'staged in your drafts · nothing sends itself',
+    logged: '✓ Kept in drafts — you send each one',
+  },
+  {
+    label: 'Report',
+    kind: 'Reporting',
+    receipt: 'traceable',
+    claim: 'Built this month’s client report for the Meridian mandate.',
+    evidence: 'white-label PDF · every number traces to a record',
+    logged: '✓ Report ready — decision logged',
+  },
+];
+
+// Server-render the strongest single frame (Matching) so the page is complete
+// before JS and for reduced-motion / screenshot / share.
+const start = 2;
+const initial = pillars[start];
+---
+
+<Layout
+  title="PA-OS — the operating system for placement agents"
+  description="PA-OS runs the whole raise on one agent: search, standardization, matching, campaigns, and reporting — every claim cited, nothing sent without your review. Closed beta."
+  ogImage="/api/og/pa-os.png"
+  ogImageAlt="PA-OS — the operating system for placement agents: source, standardize, match, campaigns, report."
+>
+  <main class="stage">
+    <a class="mark" href="/" aria-label="controlthrive home">
+      <span class="mark__glyph"><Glyph size={15} /></span>
+      <span class="mark__word">controlthrive</span>
+    </a>
+
+    <section class="lede-col">
+      <p class="tag"><i class="dot-live"></i>PA-OS · closed beta</p>
+      <h1 class="h1">The operating system for placement agents.</h1>
+      <p class="lede">
+        Search, standardization, matching, campaigns, and reporting — one agent,
+        one chat, on top of the CRM you already use. Every claim carries a
+        receipt, and nothing sends itself.
+      </p>
+    </section>
+
+    <!-- All five pillars at once; a pulse walks the rail and the tile shows the
+         lit pillar's cited receipt. Breadth legible at a glance. -->
+    <section class="os" data-os aria-label="PA-OS — the five jobs of a raise">
+      <ol class="os__rail">
+        {pillars.map((p, i) => (
+          <li class={`os__pillar${i === start ? ' is-active' : ''}`} data-pillar={i}>
+            <span class="os__dot"></span>
+            <span class="os__label">{p.label}</span>
+          </li>
+        ))}
+      </ol>
+
+      <article class="os__tile">
+        <div class="os__kindrow">
+          <span class="os__kind" data-os-kind>{initial.kind}</span>
+          <span class="os__receipt" data-os-receipt>{initial.receipt}</span>
+        </div>
+        <p class="os__claim" data-os-claim>{initial.claim}</p>
+        <p class="os__evidence" data-os-evidence>{initial.evidence}</p>
+        <div class="os__actions">
+          <span class="os__approve">Approve</span>
+          <span class="os__edit">Edit</span>
+          <span class="os__logged" data-os-logged>{initial.logged}</span>
+        </div>
+      </article>
+
+      <p class="os__foot">nothing ships without human review</p>
+    </section>
+
+    <div class="cta">
+      <a class="btn-ink" href={requestAccess}>Request access</a>
+      <span class="cta__note">closed beta · for placement agents &amp; independent bankers</span>
+    </div>
+  </main>
+
+  <script is:inline define:vars={{ pillars, start }}>
+    const root = document.querySelector('[data-os]');
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    if (root && !reduceMotion) {
+      const railItems = Array.from(root.querySelectorAll('.os__pillar'));
+      const tile = root.querySelector('.os__tile');
+      const f = {
+        kind: root.querySelector('[data-os-kind]'),
+        receipt: root.querySelector('[data-os-receipt]'),
+        claim: root.querySelector('[data-os-claim]'),
+        evidence: root.querySelector('[data-os-evidence]'),
+        logged: root.querySelector('[data-os-logged]'),
+      };
+
+      let i = start;
+
+      const render = (n) => {
+        const p = pillars[n];
+        railItems.forEach((el, idx) => el.classList.toggle('is-active', idx === n));
+        if (f.kind) f.kind.textContent = p.kind;
+        if (f.receipt) f.receipt.textContent = p.receipt;
+        if (f.claim) f.claim.textContent = p.claim;
+        if (f.evidence) f.evidence.textContent = p.evidence;
+        if (f.logged) f.logged.textContent = p.logged;
+      };
+
+      setInterval(() => {
+        tile?.classList.add('is-swapping');
+        setTimeout(() => {
+          i = (i + 1) % pillars.length;
+          render(i);
+          tile?.classList.remove('is-swapping');
+        }, 260);
+      }, 2600);
+    }
+  </script>
+
+  <style>
+    .stage {
+      min-height: 100svh;
+      display: grid;
+      grid-template-rows: auto 1fr auto;
+      gap: clamp(1.75rem, 4vh, 3rem);
+      max-width: 720px;
+      margin-inline: auto;
+      padding: clamp(1.5rem, 5vw, 2.75rem) clamp(1.25rem, 6vw, 2.5rem)
+        clamp(1.75rem, 5vh, 3rem);
+    }
+
+    /* Brand mark — navigable, not a nav bar. */
+    .mark {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.55rem;
+      color: var(--ink);
+      width: fit-content;
+    }
+    .mark__glyph {
+      display: inline-flex;
+      color: var(--ink);
+    }
+    .mark__word {
+      font-size: 0.9rem;
+      font-weight: 500;
+      letter-spacing: -0.01em;
+    }
+
+    .lede-col {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      align-self: end;
+    }
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      font-weight: 500;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+    }
+    .h1 {
+      font-size: clamp(1.9rem, 6vw, 2.85rem);
+      line-height: 1.04;
+      font-weight: 600;
+      letter-spacing: -0.02em;
+      color: var(--ink);
+      margin: 0;
+    }
+    .lede {
+      font-size: clamp(0.98rem, 2.4vw, 1.08rem);
+      line-height: 1.55;
+      color: var(--ink-2);
+      max-width: 34rem;
+      margin: 0;
+    }
+
+    /* The diagram — all five always visible. */
+    .os {
+      display: flex;
+      flex-direction: column;
+      gap: 1.35rem;
+      align-self: center;
+    }
+    .os__rail {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      position: relative;
+    }
+    /* connector line behind the dots — one system */
+    .os__rail::before {
+      content: '';
+      position: absolute;
+      left: 10%;
+      right: 10%;
+      top: 5px;
+      height: 1px;
+      background: var(--hairline-2);
+    }
+    .os__pillar {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      position: relative;
+      z-index: 1;
+    }
+    .os__dot {
+      width: 11px;
+      height: 11px;
+      border-radius: 999px;
+      background: var(--canvas);
+      box-shadow: inset 0 0 0 1.5px var(--ink-3);
+      transition:
+        box-shadow 220ms var(--ease-out),
+        background-color 220ms var(--ease-out);
+    }
+    .os__label {
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      letter-spacing: 0.02em;
+      color: var(--ink-3);
+      transition: color 220ms var(--ease-out);
+      text-align: center;
+    }
+    .os__pillar.is-active .os__dot {
+      background: var(--live);
+      box-shadow:
+        inset 0 0 0 1.5px var(--live),
+        0 0 0 4px color-mix(in srgb, var(--live) 18%, transparent);
+    }
+    .os__pillar.is-active .os__label {
+      color: var(--ink);
+    }
+
+    .os__tile {
+      background: var(--surface);
+      border: 1px solid var(--hairline);
+      border-radius: var(--radius-pane);
+      box-shadow: var(--shadow-lift);
+      padding: 1.1rem 1.2rem 1rem;
+      display: flex;
+      flex-direction: column;
+      gap: 0.55rem;
+      transition: opacity 240ms var(--ease-out), transform 240ms var(--ease-out);
+    }
+    .os__tile.is-swapping {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+    .os__kindrow {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+    .os__kind {
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      font-weight: 500;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--ink);
+    }
+    .os__receipt {
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      letter-spacing: 0.02em;
+      color: var(--ink-3);
+    }
+    .os__receipt::before {
+      content: '● ';
+      color: var(--live);
+      font-size: 0.6em;
+      vertical-align: middle;
+    }
+    .os__claim {
+      font-size: 0.98rem;
+      line-height: 1.4;
+      color: var(--ink);
+      margin: 0;
+    }
+    .os__evidence {
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      line-height: 1.4;
+      color: var(--ink-3);
+      margin: 0;
+    }
+    .os__actions {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-top: 0.15rem;
+      flex-wrap: wrap;
+    }
+    .os__approve,
+    .os__edit {
+      font-size: 0.75rem;
+      font-weight: 500;
+      padding: 0.28rem 0.7rem;
+      border-radius: 7px;
+    }
+    .os__approve {
+      background: var(--ink);
+      color: var(--surface);
+    }
+    .os__edit {
+      color: var(--ink-2);
+      border: 1px solid var(--hairline);
+    }
+    .os__logged {
+      margin-left: auto;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      color: var(--ink-3);
+    }
+    .os__foot {
+      text-align: center;
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      letter-spacing: 0.04em;
+      color: var(--ink-3);
+      margin: 0;
+    }
+
+    .cta {
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+    .cta__note {
+      font-family: var(--font-mono);
+      font-size: 0.6875rem;
+      letter-spacing: 0.02em;
+      color: var(--ink-3);
+    }
+
+    @media (max-width: 520px) {
+      .os__logged {
+        margin-left: 0;
+        width: 100%;
+      }
+      .os__label {
+        font-size: 0.625rem;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .os__tile {
+        transition: none;
+      }
+    }
+  </style>
+</Layout>

--- a/apps/website/src/pages/pa-os.astro
+++ b/apps/website/src/pages/pa-os.astro
@@ -15,45 +15,66 @@ const pillars = [
     icon: svg('<circle cx="7" cy="7" r="4"/><path d="M10.2 10.2 14 14"/>'),
     kind: 'Sourcing',
     receipt: 'cited',
-    claim: 'Found 14 new investors for the Meridian mandate.',
-    evidence: 'deduped against your book · sources attached',
-    logged: '✓ Added to mandate — decision logged',
+    agent: 'searched the web + your book',
+    claim: 'Found 10 family offices for the Meridian mandate.',
+    rows: [
+      { primary: 'Rockmont Family Office', secondary: '€20M avg check · EU real estate', action: 'Approve' },
+      { primary: 'Aldwych Capital Office', secondary: '€10–30M · value-add RE', action: 'Approve' },
+    ],
+    more: '+ 8 more',
+    footer: 'deduped against your book · every source attached',
   },
   {
     label: 'Standardize',
     icon: svg('<path d="M2.5 3.5h11"/><path d="M4.6 6v6.5M8 6v6.5M11.4 6v6.5"/>'),
     kind: 'Standardization',
     receipt: 'sourced',
-    claim: 'Turned the pitch deck into a typed, provenance-quoted mandate.',
-    evidence: 'deck p.4 — “seeking €40 million in commitments”',
-    logged: '✓ Mandate created — decision logged',
+    agent: 'read the pitch deck',
+    claim: 'Turned a 34-page deck into a typed mandate.',
+    rows: [
+      { primary: 'Asset class → Real estate', secondary: 'deck p.2', action: 'Approve' },
+      { primary: 'Target raise → €40M', secondary: 'deck p.4', action: 'Approve' },
+      { primary: 'Check size → €5–15M', secondary: 'deck p.6', action: 'Approve' },
+    ],
+    footer: 'every field quoted to its source page',
   },
   {
     label: 'Match',
     icon: svg('<path d="M2 4l3 4-3 4M14 4l-3 4 3 4"/><circle cx="8" cy="8" r="0.7" fill="currentColor" stroke="none"/>'),
     kind: 'Matching',
     receipt: 'cited',
-    claim: 'Ranked 60 investors — who to approach, in what order, and why.',
-    evidence: 'each rank cited · do-not-contact enforced',
-    logged: '✓ Target list saved — decision logged',
+    agent: 'ranked your book vs. the mandate',
+    claim: 'Ranked 60 investors — here’s the top 3.',
+    rows: [
+      { primary: '1 · Rockmont Family Office', secondary: '94 fit · invests EU RE, €20M ticket', action: 'why' },
+      { primary: '2 · Meridian Trust', secondary: '89 fit · value-add mandate', action: 'why' },
+      { primary: '3 · Aldwych Capital Office', secondary: '85 fit · ticket size match', action: 'why' },
+    ],
+    footer: 'each rank cited · do-not-contact enforced',
   },
   {
     label: 'Campaigns',
     icon: svg('<path d="M14 2 7 9"/><path d="M14 2 9.5 14 7 9 2 6.5 14 2z"/>'),
     kind: 'Campaigns',
     receipt: 'for review',
-    claim: 'Drafted 38 outreach emails from the record.',
-    evidence: 'staged in your drafts · nothing sends itself',
-    logged: '✓ Kept in drafts — you send each one',
+    agent: 'drafted outreach from the record',
+    claim: '38 emails drafted — staged in your drafts.',
+    rows: [
+      { primary: 'To: Rockmont Family Office', secondary: '“Meridian — EU real estate, €20M ticket…”', action: 'Review draft' },
+    ],
+    footer: 'nothing sends itself — you send each one',
   },
   {
     label: 'Report',
     icon: svg('<path d="M4 2.5h5L12 5.5v8H4z"/><path d="M6.2 8.6h3.6M6.2 11h3.6"/>'),
     kind: 'Reporting',
     receipt: 'traceable',
-    claim: 'Built this month’s client report for the Meridian mandate.',
-    evidence: 'white-label PDF · every number traces to a record',
-    logged: '✓ Report ready — decision logged',
+    agent: 'built this month’s client report',
+    claim: 'Meridian — activity report ready.',
+    rows: [
+      { primary: '12 emails · 5 meetings · 3 calls', secondary: '€40M pipeline · 60 investors touched', action: 'Open PDF' },
+    ],
+    footer: 'white-label PDF · every number traces to a record',
   },
 ];
 
@@ -105,17 +126,27 @@ const initial = pillars[start];
       </div>
 
       <article class="os__tile">
-        <div class="os__kindrow">
-          <span class="os__kind" data-os-kind>{initial.kind}</span>
+        <div class="os__cardhead">
+          <span class="os__agent">
+            <span class="os__agenticon"><Glyph size={12} /></span>
+            Agent · <span data-os-agent>{initial.agent}</span>
+          </span>
           <span class="os__receipt" data-os-receipt>{initial.receipt}</span>
         </div>
         <p class="os__claim" data-os-claim>{initial.claim}</p>
-        <p class="os__evidence" data-os-evidence>{initial.evidence}</p>
-        <div class="os__actions">
-          <span class="os__approve">Approve</span>
-          <span class="os__edit">Edit</span>
-          <span class="os__logged" data-os-logged>{initial.logged}</span>
-        </div>
+        <ul class="os__rows" data-os-rows>
+          {initial.rows.map((r) => (
+            <li class="os__row">
+              <span class="os__rowtext">
+                <strong>{r.primary}</strong>
+                <span>{r.secondary}</span>
+              </span>
+              <span class={`os__chip${r.action === 'Approve' ? '' : ' os__chip--ghost'}`}>{r.action}</span>
+            </li>
+          ))}
+          {initial.more && <li class="os__more">{initial.more}</li>}
+        </ul>
+        <p class="os__note" data-os-note>{initial.footer}</p>
       </article>
 
       <p class="os__foot">nothing ships without human review</p>
@@ -134,45 +165,88 @@ const initial = pillars[start];
 
     if (root && diagram && !reduceMotion) {
       const railItems = Array.from(root.querySelectorAll('.os__pillar'));
+      const rail = root.querySelector('.os__rail');
       const tile = root.querySelector('.os__tile');
+      const rowsEl = root.querySelector('[data-os-rows]');
       const f = {
-        kind: root.querySelector('[data-os-kind]'),
+        agent: root.querySelector('[data-os-agent]'),
         receipt: root.querySelector('[data-os-receipt]'),
         claim: root.querySelector('[data-os-claim]'),
-        evidence: root.querySelector('[data-os-evidence]'),
-        logged: root.querySelector('[data-os-logged]'),
+        note: root.querySelector('[data-os-note]'),
+      };
+
+      const renderRows = (p) => {
+        if (!rowsEl) return;
+        rowsEl.replaceChildren();
+        p.rows.forEach((r) => {
+          const li = document.createElement('li');
+          li.className = 'os__row';
+          const text = document.createElement('span');
+          text.className = 'os__rowtext';
+          const strong = document.createElement('strong');
+          strong.textContent = r.primary;
+          const sec = document.createElement('span');
+          sec.textContent = r.secondary;
+          text.append(strong, sec);
+          const chip = document.createElement('span');
+          chip.className = 'os__chip' + (r.action === 'Approve' ? '' : ' os__chip--ghost');
+          chip.textContent = r.action;
+          li.append(text, chip);
+          rowsEl.append(li);
+        });
+        if (p.more) {
+          const li = document.createElement('li');
+          li.className = 'os__more';
+          li.textContent = p.more;
+          rowsEl.append(li);
+        }
       };
 
       const fillTile = (n) => {
         const p = pillars[n];
-        if (f.kind) f.kind.textContent = p.kind;
+        if (f.agent) f.agent.textContent = p.agent;
         if (f.receipt) f.receipt.textContent = p.receipt;
         if (f.claim) f.claim.textContent = p.claim;
-        if (f.evidence) f.evidence.textContent = p.evidence;
-        if (f.logged) f.logged.textContent = p.logged;
+        if (f.note) f.note.textContent = p.footer;
+        renderRows(p);
       };
 
       const TRAVEL = 900; // the glow glides the rail
       const DWELL = 4200; // rest on each pillar
+      const CYCLE = TRAVEL + DWELL;
 
       let i = start;
 
-      const step = () => {
-        const next = (i + 1) % pillars.length;
-        // send the glow + progress line toward the next pillar
-        diagram.style.setProperty('--i', String(next));
-        // fade the tile while the pulse is in transit
+      // Move the glow to pillar n; swap the card in after `delay` (once the glow
+      // has travelled, on auto-play; quickly, on hover).
+      const activate = (n, delay) => {
+        diagram.style.setProperty('--i', String(n));
         tile?.classList.add('is-swapping');
         window.setTimeout(() => {
-          railItems[i]?.classList.remove('is-active');
-          railItems[next]?.classList.add('is-active');
-          fillTile(next);
+          railItems.forEach((el, idx) => el.classList.toggle('is-active', idx === n));
+          fillTile(n);
           tile?.classList.remove('is-swapping');
-          i = next;
-        }, TRAVEL);
+        }, delay);
+        i = n;
       };
 
-      window.setInterval(step, DWELL + TRAVEL);
+      const step = () => activate((i + 1) % pillars.length, TRAVEL);
+
+      let timer = window.setInterval(step, CYCLE);
+
+      // Hover (or tap) a pillar to pin its card and pause; leaving the rail resumes.
+      railItems.forEach((el, idx) => {
+        const jump = () => {
+          window.clearInterval(timer);
+          if (idx !== i) activate(idx, 220);
+        };
+        el.addEventListener('mouseenter', jump);
+        el.addEventListener('click', jump);
+      });
+      rail?.addEventListener('mouseleave', () => {
+        window.clearInterval(timer);
+        timer = window.setInterval(step, CYCLE);
+      });
     }
   </script>
 
@@ -391,25 +465,38 @@ const initial = pillars[start];
       opacity: 0;
       transform: translateY(8px);
     }
-    .os__kindrow {
+    .os__cardhead {
       display: flex;
       align-items: center;
       justify-content: space-between;
       gap: 1rem;
     }
-    .os__kind {
+    .os__agent {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.4rem;
       font-family: var(--font-mono);
       font-size: 0.6875rem;
       font-weight: 500;
-      letter-spacing: 0.06em;
+      letter-spacing: 0.05em;
       text-transform: uppercase;
       color: var(--ink);
+    }
+    .os__agenticon {
+      display: inline-flex;
+      color: var(--live);
+    }
+    .os__agenticon :global(svg) {
+      width: 12px;
+      height: 12px;
+      display: block;
     }
     .os__receipt {
       font-family: var(--font-mono);
       font-size: 0.6875rem;
       letter-spacing: 0.02em;
       color: var(--ink-3);
+      white-space: nowrap;
     }
     .os__receipt::before {
       content: '● ';
@@ -419,44 +506,75 @@ const initial = pillars[start];
     }
     .os__claim {
       font-size: 0.98rem;
-      line-height: 1.4;
+      line-height: 1.35;
+      font-weight: 550;
       color: var(--ink);
-      margin: 0;
+      margin: 0.1rem 0 0.15rem;
     }
-    .os__evidence {
-      font-family: var(--font-mono);
-      font-size: 0.75rem;
-      line-height: 1.4;
-      color: var(--ink-3);
+    .os__rows {
+      list-style: none;
       margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.45rem;
     }
-    .os__actions {
+    .os__row {
       display: flex;
       align-items: center;
-      gap: 0.5rem;
-      margin-top: 0.15rem;
-      flex-wrap: wrap;
-    }
-    .os__approve,
-    .os__edit {
-      font-size: 0.75rem;
-      font-weight: 500;
-      padding: 0.28rem 0.7rem;
-      border-radius: 7px;
-    }
-    .os__approve {
-      background: var(--ink);
-      color: var(--surface);
-    }
-    .os__edit {
-      color: var(--ink-2);
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.5rem 0.6rem;
       border: 1px solid var(--hairline);
+      border-radius: 8px;
+      background: var(--canvas);
     }
-    .os__logged {
-      margin-left: auto;
+    .os__rowtext {
+      display: flex;
+      flex-direction: column;
+      gap: 0.1rem;
+      min-width: 0;
+    }
+    .os__rowtext strong {
+      font-size: 0.82rem;
+      font-weight: 550;
+      color: var(--ink);
+    }
+    .os__rowtext > span {
       font-family: var(--font-mono);
       font-size: 0.72rem;
       color: var(--ink-3);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .os__chip {
+      flex: none;
+      font-size: 0.72rem;
+      font-weight: 500;
+      padding: 0.3rem 0.66rem;
+      border-radius: 6px;
+      background: var(--ink);
+      color: var(--surface);
+    }
+    .os__chip--ghost {
+      background: transparent;
+      color: var(--ink-2);
+      border: 1px solid var(--hairline-2);
+    }
+    .os__more {
+      font-family: var(--font-mono);
+      font-size: 0.7rem;
+      letter-spacing: 0.02em;
+      color: var(--ink-3);
+      padding-left: 0.2rem;
+    }
+    .os__note {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      line-height: 1.4;
+      color: var(--ink-3);
+      margin: 0.15rem 0 0;
     }
     .os__foot {
       text-align: center;
@@ -481,12 +599,11 @@ const initial = pillars[start];
     }
 
     @media (max-width: 520px) {
-      .os__logged {
-        margin-left: 0;
-        width: 100%;
-      }
       .os__label {
         font-size: 0.625rem;
+      }
+      .os__rowtext > span {
+        white-space: normal;
       }
     }
 

--- a/apps/website/src/pages/pa-os.astro
+++ b/apps/website/src/pages/pa-os.astro
@@ -7,9 +7,13 @@ const requestAccess = 'mailto:servando@controlthrive.com?subject=PA-OS%20access'
 // The five pillars of a raise, each an agent taking one action under the same
 // cited, human-approved contract. Rail labels stay short; the focus tile shows
 // the full receipt. Copy shared with the homepage vignette.
+const svg = (paths: string) =>
+  `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
+
 const pillars = [
   {
     label: 'Source',
+    icon: svg('<circle cx="7" cy="7" r="4"/><path d="M10.2 10.2 14 14"/>'),
     kind: 'Sourcing',
     receipt: 'cited',
     claim: 'Found 14 new investors for the Meridian mandate.',
@@ -18,6 +22,7 @@ const pillars = [
   },
   {
     label: 'Standardize',
+    icon: svg('<path d="M2.5 3.5h11"/><path d="M4.6 6v6.5M8 6v6.5M11.4 6v6.5"/>'),
     kind: 'Standardization',
     receipt: 'sourced',
     claim: 'Turned the pitch deck into a typed, provenance-quoted mandate.',
@@ -26,6 +31,7 @@ const pillars = [
   },
   {
     label: 'Match',
+    icon: svg('<path d="M2 4l3 4-3 4M14 4l-3 4 3 4"/><circle cx="8" cy="8" r="0.7" fill="currentColor" stroke="none"/>'),
     kind: 'Matching',
     receipt: 'cited',
     claim: 'Ranked 60 investors — who to approach, in what order, and why.',
@@ -34,6 +40,7 @@ const pillars = [
   },
   {
     label: 'Campaigns',
+    icon: svg('<path d="M14 2 7 9"/><path d="M14 2 9.5 14 7 9 2 6.5 14 2z"/>'),
     kind: 'Campaigns',
     receipt: 'for review',
     claim: 'Drafted 38 outreach emails from the record.',
@@ -42,6 +49,7 @@ const pillars = [
   },
   {
     label: 'Report',
+    icon: svg('<path d="M4 2.5h5L12 5.5v8H4z"/><path d="M6.2 8.6h3.6M6.2 11h3.6"/>'),
     kind: 'Reporting',
     receipt: 'traceable',
     claim: 'Built this month’s client report for the Meridian mandate.',
@@ -81,14 +89,21 @@ const initial = pillars[start];
     <!-- All five pillars at once; a pulse walks the rail and the tile shows the
          lit pillar's cited receipt. Breadth legible at a glance. -->
     <section class="os" data-os aria-label="PA-OS — the five jobs of a raise">
-      <ol class="os__rail">
-        {pillars.map((p, i) => (
-          <li class={`os__pillar${i === start ? ' is-active' : ''}`} data-pillar={i}>
-            <span class="os__dot"></span>
-            <span class="os__label">{p.label}</span>
-          </li>
-        ))}
-      </ol>
+      <div class="os__diagram" style={`--i:${start}`}>
+        <div class="os__track" aria-hidden="true">
+          <span class="os__fill"></span>
+        </div>
+        <span class="os__orb" aria-hidden="true"></span>
+        <ol class="os__rail">
+          {pillars.map((p, i) => (
+            <li class={`os__pillar${i === start ? ' is-active' : ''}`} data-pillar={i}>
+              <span class="os__dot"></span>
+              <span class="os__icon" set:html={p.icon} />
+              <span class="os__label">{p.label}</span>
+            </li>
+          ))}
+        </ol>
+      </div>
 
       <article class="os__tile">
         <div class="os__kindrow">
@@ -115,9 +130,10 @@ const initial = pillars[start];
 
   <script is:inline define:vars={{ pillars, start }}>
     const root = document.querySelector('[data-os]');
+    const diagram = root && root.querySelector('.os__diagram');
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-    if (root && !reduceMotion) {
+    if (root && diagram && !reduceMotion) {
       const railItems = Array.from(root.querySelectorAll('.os__pillar'));
       const tile = root.querySelector('.os__tile');
       const f = {
@@ -128,11 +144,8 @@ const initial = pillars[start];
         logged: root.querySelector('[data-os-logged]'),
       };
 
-      let i = start;
-
-      const render = (n) => {
+      const fillTile = (n) => {
         const p = pillars[n];
-        railItems.forEach((el, idx) => el.classList.toggle('is-active', idx === n));
         if (f.kind) f.kind.textContent = p.kind;
         if (f.receipt) f.receipt.textContent = p.receipt;
         if (f.claim) f.claim.textContent = p.claim;
@@ -140,14 +153,27 @@ const initial = pillars[start];
         if (f.logged) f.logged.textContent = p.logged;
       };
 
-      setInterval(() => {
+      const TRAVEL = 900; // the glow glides the rail
+      const DWELL = 4200; // rest on each pillar
+
+      let i = start;
+
+      const step = () => {
+        const next = (i + 1) % pillars.length;
+        // send the glow + progress line toward the next pillar
+        diagram.style.setProperty('--i', String(next));
+        // fade the tile while the pulse is in transit
         tile?.classList.add('is-swapping');
-        setTimeout(() => {
-          i = (i + 1) % pillars.length;
-          render(i);
+        window.setTimeout(() => {
+          railItems[i]?.classList.remove('is-active');
+          railItems[next]?.classList.add('is-active');
+          fillTile(next);
           tile?.classList.remove('is-swapping');
-        }, 260);
-      }, 2600);
+          i = next;
+        }, TRAVEL);
+      };
+
+      window.setInterval(step, DWELL + TRAVEL);
     }
   </script>
 
@@ -214,65 +240,141 @@ const initial = pillars[start];
       margin: 0;
     }
 
-    /* The diagram — all five always visible. */
+    /* The diagram — all five pillars always visible; a glow travels the rail. */
     .os {
       display: flex;
       flex-direction: column;
-      gap: 1.35rem;
+      gap: 1.75rem;
       align-self: center;
     }
+
+    /* --i (0..4), set inline and advanced by JS, drives the fill + orb. */
+    .os__diagram {
+      position: relative;
+    }
+
+    /* base track under the row of dots */
+    .os__track {
+      position: absolute;
+      left: 10%;
+      right: 10%;
+      top: 5px;
+      height: 2px;
+      border-radius: 2px;
+      background: var(--hairline-2);
+    }
+    /* progress line — fills from the first pillar to the active one */
+    .os__fill {
+      position: absolute;
+      left: 0;
+      top: 0;
+      height: 100%;
+      width: calc(var(--i, 0) * 25%);
+      border-radius: 2px;
+      background: linear-gradient(
+        90deg,
+        color-mix(in srgb, var(--live) 40%, transparent),
+        var(--live)
+      );
+      transition: width 900ms var(--ease-out);
+    }
+    /* the travelling pulse */
+    .os__orb {
+      position: absolute;
+      top: 6px;
+      left: calc(10% + var(--i, 0) * 20%);
+      width: 12px;
+      height: 12px;
+      border-radius: 999px;
+      background: var(--live);
+      transform: translate(-50%, -50%);
+      box-shadow:
+        0 0 0 5px color-mix(in srgb, var(--live) 15%, transparent),
+        0 0 16px 3px color-mix(in srgb, var(--live) 55%, transparent);
+      transition: left 900ms var(--ease-out);
+      z-index: 3;
+    }
+
     .os__rail {
+      position: relative;
+      z-index: 2;
       list-style: none;
       margin: 0;
       padding: 0;
       display: grid;
       grid-template-columns: repeat(5, 1fr);
-      position: relative;
-    }
-    /* connector line behind the dots — one system */
-    .os__rail::before {
-      content: '';
-      position: absolute;
-      left: 10%;
-      right: 10%;
-      top: 5px;
-      height: 1px;
-      background: var(--hairline-2);
     }
     .os__pillar {
       display: flex;
       flex-direction: column;
       align-items: center;
-      gap: 0.5rem;
-      position: relative;
-      z-index: 1;
+      gap: 0.65rem;
     }
     .os__dot {
-      width: 11px;
-      height: 11px;
+      position: relative;
+      width: 12px;
+      height: 12px;
       border-radius: 999px;
       background: var(--canvas);
       box-shadow: inset 0 0 0 1.5px var(--ink-3);
       transition:
-        box-shadow 220ms var(--ease-out),
-        background-color 220ms var(--ease-out);
+        box-shadow 300ms var(--ease-out),
+        background-color 300ms var(--ease-out);
+    }
+    .os__icon {
+      display: inline-flex;
+      color: var(--ink-3);
+      transition:
+        color 300ms var(--ease-out),
+        transform 300ms var(--ease-out);
+    }
+    .os__icon :global(svg) {
+      width: 17px;
+      height: 17px;
+      display: block;
     }
     .os__label {
       font-family: var(--font-mono);
       font-size: 0.6875rem;
       letter-spacing: 0.02em;
       color: var(--ink-3);
-      transition: color 220ms var(--ease-out);
+      transition: color 300ms var(--ease-out);
       text-align: center;
     }
+
+    /* active pillar — filled dot with an expanding ripple, lit icon + label */
     .os__pillar.is-active .os__dot {
       background: var(--live);
-      box-shadow:
-        inset 0 0 0 1.5px var(--live),
-        0 0 0 4px color-mix(in srgb, var(--live) 18%, transparent);
+      box-shadow: inset 0 0 0 1.5px var(--live);
+    }
+    .os__pillar.is-active .os__dot::after {
+      content: '';
+      position: absolute;
+      inset: -4px;
+      border-radius: 999px;
+      border: 1.5px solid var(--live);
+      animation: os-ripple 1800ms var(--ease-out) infinite;
+    }
+    .os__pillar.is-active .os__icon {
+      color: var(--live);
+      transform: translateY(-1px) scale(1.1);
     }
     .os__pillar.is-active .os__label {
       color: var(--ink);
+    }
+
+    @keyframes os-ripple {
+      0% {
+        transform: scale(0.6);
+        opacity: 0.9;
+      }
+      70% {
+        opacity: 0;
+      }
+      100% {
+        transform: scale(2.2);
+        opacity: 0;
+      }
     }
 
     .os__tile {
@@ -284,11 +386,11 @@ const initial = pillars[start];
       display: flex;
       flex-direction: column;
       gap: 0.55rem;
-      transition: opacity 240ms var(--ease-out), transform 240ms var(--ease-out);
+      transition: opacity 380ms var(--ease-out), transform 380ms var(--ease-out);
     }
     .os__tile.is-swapping {
       opacity: 0;
-      transform: translateY(4px);
+      transform: translateY(8px);
     }
     .os__kindrow {
       display: flex;
@@ -390,8 +492,13 @@ const initial = pillars[start];
     }
 
     @media (prefers-reduced-motion: reduce) {
-      .os__tile {
+      .os__tile,
+      .os__fill,
+      .os__orb {
         transition: none;
+      }
+      .os__pillar.is-active .os__dot::after {
+        animation: none;
       }
     }
   </style>

--- a/apps/website/src/pages/pa-os.astro
+++ b/apps/website/src/pages/pa-os.astro
@@ -291,7 +291,10 @@ const initial = pillars[start];
     }
   </script>
 
-  <style>
+  <!-- Global (not scoped): the tile rows are rebuilt in JS, and scoped styles
+       only attach to server-rendered elements. This is a standalone page and
+       every selector is os__/page-prefixed, so global is safe here. -->
+  <style is:global>
     .stage {
       min-height: 100svh;
       display: grid;

--- a/apps/website/src/pages/pa-os.astro
+++ b/apps/website/src/pages/pa-os.astro
@@ -9,78 +9,82 @@ import { bookingUrl } from '../lib/siteContent';
 const svg = (paths: string) =>
   `<svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths}</svg>`;
 
+const extIcon = svg('<path d="M9 3.5h3.5V7"/><path d="M12.5 3.5 7.5 8.5"/><path d="M11 9.5v3H3.5V5H6.5"/>');
+
+// Each pillar mirrors the real product panel: a header with counts + an
+// "Open …" link, an optional evidence note, and hairline rows that each carry a
+// state — an outline action button, or a status (In pipeline / Passed) + link.
 const pillars = [
   {
     label: 'Source',
     icon: svg('<circle cx="7" cy="7" r="4"/><path d="M10.2 10.2 14 14"/>'),
-    kind: 'Sourcing',
-    receipt: 'cited',
-    agent: 'searched the web + your book',
-    claim: 'Found 10 family offices for the Meridian mandate.',
+    head: 'Investor discovery · Project Meridian',
+    meta: '8 reviewable of 12 found · 19 Jul 2026',
+    link: 'Open mandate',
+    note: '4 candidates withheld — no source evidence, so PA-OS won’t present them for approval.',
     rows: [
-      { primary: 'Rockmont Family Office', secondary: '€20M avg check · EU real estate', action: 'Approve' },
-      { primary: 'Aldwych Capital Office', secondary: '€10–30M · value-add RE', action: 'Approve' },
+      { n: '1', name: 'Rockmont Family Office', detail: '€20M avg check · EU real estate · Helsinki', badge: 'New', state: 'in', status: 'In pipeline', link: 'Open' },
+      { n: '2', name: 'Aldwych Capital Office', detail: '€10–30M · value-add RE · London', badge: 'New', state: 'action', action: 'Add to Meridian', link: 'Pass' },
+      { n: '5', name: 'Talstein Multi-Family Office', detail: '€15M avg · diversified · Zurich', badge: 'New', state: 'passed', status: 'Passed', link: 'Reconsider' },
     ],
-    more: '+ 8 more',
-    footer: 'deduped against your book · every source attached',
   },
   {
     label: 'Standardize',
     icon: svg('<path d="M2.5 3.5h11"/><path d="M4.6 6v6.5M8 6v6.5M11.4 6v6.5"/>'),
-    kind: 'Standardization',
-    receipt: 'sourced',
-    agent: 'read the pitch deck',
-    claim: 'Turned a 34-page deck into a typed mandate.',
+    head: 'Mandate extraction · Project Meridian',
+    meta: '9 fields typed · 2 flagged · 19 Jul 2026',
+    link: 'Open mandate',
+    note: '2 low-confidence fields — quoted to source, flagged for your review.',
     rows: [
-      { primary: 'Asset class → Real estate', secondary: 'deck p.2', action: 'Approve' },
-      { primary: 'Target raise → €40M', secondary: 'deck p.4', action: 'Approve' },
-      { primary: 'Check size → €5–15M', secondary: 'deck p.6', action: 'Approve' },
+      { n: '1', name: 'Asset class — Real estate', detail: 'deck p.2 · “private real estate strategies”', badge: 'p.2', state: 'action', action: 'Accept', link: 'Edit' },
+      { n: '2', name: 'Target raise — €40M', detail: 'deck p.4 · “seeking €40 million”', badge: 'p.4', state: 'in', status: 'Accepted', link: 'Open' },
+      { n: '3', name: 'Check size — €5–15M', detail: 'deck p.6 · flagged low confidence', badge: 'p.6', state: 'action', action: 'Accept', link: 'Edit' },
     ],
-    footer: 'every field quoted to its source page',
   },
   {
     label: 'Match',
     icon: svg('<path d="M2 4l3 4-3 4M14 4l-3 4 3 4"/><circle cx="8" cy="8" r="0.7" fill="currentColor" stroke="none"/>'),
-    kind: 'Matching',
-    receipt: 'cited',
-    agent: 'ranked your book vs. the mandate',
-    claim: 'Ranked 60 investors — here’s the top 3.',
+    head: 'Investor matching · Project Meridian',
+    meta: 'top 3 of 60 ranked · 19 Jul 2026',
+    link: 'Open mandate',
+    note: '',
     rows: [
-      { primary: '1 · Rockmont Family Office', secondary: '94 fit · invests EU RE, €20M ticket', action: 'why' },
-      { primary: '2 · Meridian Trust', secondary: '89 fit · value-add mandate', action: 'why' },
-      { primary: '3 · Aldwych Capital Office', secondary: '85 fit · ticket size match', action: 'why' },
+      { n: '1', name: 'Rockmont Family Office', detail: '94 fit · invests EU RE, €20M ticket', badge: '94', state: 'in', status: 'Shortlisted', link: 'Why' },
+      { n: '2', name: 'Meridian Trust Office', detail: '89 fit · value-add mandate match', badge: '89', state: 'action', action: 'Add to shortlist', link: 'Why' },
+      { n: '3', name: 'Aldwych Capital Office', detail: '85 fit · ticket size match', badge: '85', state: 'action', action: 'Add to shortlist', link: 'Why' },
     ],
-    footer: 'each rank cited · do-not-contact enforced',
   },
   {
     label: 'Campaigns',
     icon: svg('<path d="M14 2 7 9"/><path d="M14 2 9.5 14 7 9 2 6.5 14 2z"/>'),
-    kind: 'Campaigns',
-    receipt: 'for review',
-    agent: 'drafted outreach from the record',
-    claim: '38 emails drafted — staged in your drafts.',
+    head: 'Outreach drafts · Project Meridian',
+    meta: '38 drafted · staged in your drafts · 19 Jul 2026',
+    link: 'Open drafts',
+    note: 'Nothing sends itself — every draft waits for you to send.',
     rows: [
-      { primary: 'To: Rockmont Family Office', secondary: '“Meridian — EU real estate, €20M ticket…”', action: 'Review draft' },
+      { n: '1', name: 'To: Rockmont Family Office', detail: '“Meridian — EU real estate, €20M ticket…”', badge: 'Draft', state: 'action', action: 'Review draft', link: 'Discard' },
+      { n: '2', name: 'To: Aldwych Capital Office', detail: '“Following up on value-add real estate…”', badge: 'Draft', state: 'action', action: 'Review draft', link: 'Discard' },
+      { n: '3', name: 'To: Meridian Trust Office', detail: '“Introducing the Meridian mandate…”', badge: 'Draft', state: 'action', action: 'Review draft', link: 'Discard' },
     ],
-    footer: 'nothing sends itself — you send each one',
   },
   {
     label: 'Report',
     icon: svg('<path d="M4 2.5h5L12 5.5v8H4z"/><path d="M6.2 8.6h3.6M6.2 11h3.6"/>'),
-    kind: 'Reporting',
-    receipt: 'traceable',
-    agent: 'built this month’s client report',
-    claim: 'Meridian — activity report ready.',
+    head: 'Activity report · Project Meridian',
+    meta: 'this month · every figure sourced · 19 Jul 2026',
+    link: 'Open PDF',
+    note: '',
     rows: [
-      { primary: '12 emails · 5 meetings · 3 calls', secondary: '€40M pipeline · 60 investors touched', action: 'Open PDF' },
+      { n: '1', name: 'Outreach — 12 emails, 5 meetings, 3 calls', detail: 'each figure traces to a record', badge: '', state: 'action', action: 'Open PDF', link: 'Rebuild' },
+      { n: '2', name: 'Pipeline — €40M across 8 investors', detail: '3 in diligence · 2 committed', badge: '', state: 'in', status: 'In report', link: 'Open' },
+      { n: '3', name: 'Coverage — 60 of 72 mapped', detail: '12 pending review', badge: '', state: 'action', action: 'Open PDF', link: 'Rebuild' },
     ],
-    footer: 'white-label PDF · every number traces to a record',
   },
 ];
 
-// Server-render the strongest single frame (Matching) so the page is complete
-// before JS and for reduced-motion / screenshot / share.
-const start = 2;
+// Server-render Sourcing first so the page is complete before JS and for
+// reduced-motion / screenshot / share.
+const start = 0;
 const initial = pillars[start];
 ---
 
@@ -126,27 +130,40 @@ const initial = pillars[start];
       </div>
 
       <article class="os__tile">
-        <div class="os__cardhead">
-          <span class="os__agent">
-            <span class="os__agenticon"><Glyph size={12} /></span>
-            Agent · <span data-os-agent>{initial.agent}</span>
-          </span>
-          <span class="os__receipt" data-os-receipt>{initial.receipt}</span>
-        </div>
-        <p class="os__claim" data-os-claim>{initial.claim}</p>
+        <header class="os__phead">
+          <div class="os__ptitle">
+            <strong data-os-head>{initial.head}</strong>
+            <span class="os__pmeta" data-os-meta>{initial.meta}</span>
+          </div>
+          <span class="os__plink" data-os-link>{initial.link}</span>
+        </header>
+        <p class="os__pnote" data-os-note hidden={!initial.note}>{initial.note}</p>
         <ul class="os__rows" data-os-rows>
           {initial.rows.map((r) => (
             <li class="os__row">
-              <span class="os__rowtext">
-                <strong>{r.primary}</strong>
-                <span>{r.secondary}</span>
-              </span>
-              <span class={`os__chip${r.action === 'Approve' ? '' : ' os__chip--ghost'}`}>{r.action}</span>
+              <span class="os__rn">{r.n}</span>
+              <div class="os__rmain">
+                <div class="os__rnamerow">
+                  <span class="os__rname">{r.name}<span class="os__ext" set:html={extIcon} /></span>
+                  {r.badge && <span class="os__badge">{r.badge}</span>}
+                </div>
+                <div class="os__rdetail">{r.detail}</div>
+              </div>
+              <div class="os__ractions">
+                {r.state === 'action' && (
+                  <button type="button" class="os__btn"><span class="os__btnplus">+</span>{r.action}</button>
+                )}
+                {r.state === 'in' && (
+                  <span class="os__status os__status--in"><span class="os__statustick">✓</span>{r.status}</span>
+                )}
+                {r.state === 'passed' && (
+                  <span class="os__status os__status--passed"><span class="os__statustick">✕</span>{r.status}</span>
+                )}
+                <span class="os__pass">{r.link}</span>
+              </div>
             </li>
           ))}
-          {initial.more && <li class="os__more">{initial.more}</li>}
         </ul>
-        <p class="os__note" data-os-note>{initial.footer}</p>
       </article>
 
       <p class="os__foot">nothing ships without human review</p>
@@ -158,7 +175,7 @@ const initial = pillars[start];
     </div>
   </main>
 
-  <script is:inline define:vars={{ pillars, start }}>
+  <script is:inline define:vars={{ pillars, start, extIcon }}>
     const root = document.querySelector('[data-os]');
     const diagram = root && root.querySelector('.os__diagram');
     const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -169,45 +186,64 @@ const initial = pillars[start];
       const tile = root.querySelector('.os__tile');
       const rowsEl = root.querySelector('[data-os-rows]');
       const f = {
-        agent: root.querySelector('[data-os-agent]'),
-        receipt: root.querySelector('[data-os-receipt]'),
-        claim: root.querySelector('[data-os-claim]'),
+        head: root.querySelector('[data-os-head]'),
+        meta: root.querySelector('[data-os-meta]'),
+        link: root.querySelector('[data-os-link]'),
         note: root.querySelector('[data-os-note]'),
+      };
+
+      const el = (tag, cls, text) => {
+        const n = document.createElement(tag);
+        if (cls) n.className = cls;
+        if (text != null) n.textContent = text;
+        return n;
       };
 
       const renderRows = (p) => {
         if (!rowsEl) return;
         rowsEl.replaceChildren();
         p.rows.forEach((r) => {
-          const li = document.createElement('li');
-          li.className = 'os__row';
-          const text = document.createElement('span');
-          text.className = 'os__rowtext';
-          const strong = document.createElement('strong');
-          strong.textContent = r.primary;
-          const sec = document.createElement('span');
-          sec.textContent = r.secondary;
-          text.append(strong, sec);
-          const chip = document.createElement('span');
-          chip.className = 'os__chip' + (r.action === 'Approve' ? '' : ' os__chip--ghost');
-          chip.textContent = r.action;
-          li.append(text, chip);
+          const li = el('li', 'os__row');
+          li.append(el('span', 'os__rn', r.n));
+
+          const main = el('div', 'os__rmain');
+          const namerow = el('div', 'os__rnamerow');
+          const name = el('span', 'os__rname', r.name);
+          const ext = el('span', 'os__ext');
+          ext.innerHTML = extIcon;
+          name.append(ext);
+          namerow.append(name);
+          if (r.badge) namerow.append(el('span', 'os__badge', r.badge));
+          main.append(namerow, el('div', 'os__rdetail', r.detail));
+          li.append(main);
+
+          const actions = el('div', 'os__ractions');
+          if (r.state === 'action') {
+            const btn = el('button', 'os__btn');
+            btn.type = 'button';
+            btn.append(el('span', 'os__btnplus', '+'), document.createTextNode(r.action));
+            actions.append(btn);
+          } else {
+            const st = el('span', 'os__status os__status--' + r.state);
+            st.append(el('span', 'os__statustick', r.state === 'in' ? '✓' : '✕'), document.createTextNode(r.status));
+            actions.append(st);
+          }
+          actions.append(el('span', 'os__pass', r.link));
+          li.append(actions);
+
           rowsEl.append(li);
         });
-        if (p.more) {
-          const li = document.createElement('li');
-          li.className = 'os__more';
-          li.textContent = p.more;
-          rowsEl.append(li);
-        }
       };
 
       const fillTile = (n) => {
         const p = pillars[n];
-        if (f.agent) f.agent.textContent = p.agent;
-        if (f.receipt) f.receipt.textContent = p.receipt;
-        if (f.claim) f.claim.textContent = p.claim;
-        if (f.note) f.note.textContent = p.footer;
+        if (f.head) f.head.textContent = p.head;
+        if (f.meta) f.meta.textContent = p.meta;
+        if (f.link) f.link.textContent = p.link;
+        if (f.note) {
+          f.note.textContent = p.note || '';
+          f.note.hidden = !p.note;
+        }
         renderRows(p);
       };
 
@@ -465,116 +501,168 @@ const initial = pillars[start];
       opacity: 0;
       transform: translateY(8px);
     }
-    .os__cardhead {
+    .os__phead {
       display: flex;
-      align-items: center;
+      align-items: baseline;
       justify-content: space-between;
       gap: 1rem;
     }
-    .os__agent {
-      display: inline-flex;
-      align-items: center;
-      gap: 0.4rem;
-      font-family: var(--font-mono);
-      font-size: 0.6875rem;
-      font-weight: 500;
-      letter-spacing: 0.05em;
-      text-transform: uppercase;
+    .os__ptitle {
+      display: flex;
+      flex-direction: column;
+      gap: 0.15rem;
+      min-width: 0;
+    }
+    .os__ptitle strong {
+      font-size: 0.9rem;
+      font-weight: 600;
+      letter-spacing: -0.005em;
       color: var(--ink);
     }
-    .os__agenticon {
-      display: inline-flex;
-      color: var(--live);
-    }
-    .os__agenticon :global(svg) {
-      width: 12px;
-      height: 12px;
-      display: block;
-    }
-    .os__receipt {
+    .os__pmeta {
       font-family: var(--font-mono);
-      font-size: 0.6875rem;
-      letter-spacing: 0.02em;
+      font-size: 0.68rem;
       color: var(--ink-3);
-      white-space: nowrap;
     }
-    .os__receipt::before {
-      content: '● ';
-      color: var(--live);
-      font-size: 0.6em;
-      vertical-align: middle;
+    .os__plink {
+      flex: none;
+      font-size: 0.78rem;
+      font-weight: 500;
+      color: var(--ink-2);
     }
-    .os__claim {
-      font-size: 0.98rem;
-      line-height: 1.35;
-      font-weight: 550;
-      color: var(--ink);
-      margin: 0.1rem 0 0.15rem;
+    .os__pnote {
+      font-size: 0.76rem;
+      line-height: 1.4;
+      color: #9a7d43;
+      margin: 0.15rem 0 0;
     }
     .os__rows {
       list-style: none;
-      margin: 0;
+      margin: 0.1rem 0 0;
       padding: 0;
       display: flex;
       flex-direction: column;
-      gap: 0.45rem;
     }
     .os__row {
       display: flex;
       align-items: center;
-      justify-content: space-between;
-      gap: 0.75rem;
-      padding: 0.5rem 0.6rem;
-      border: 1px solid var(--hairline);
-      border-radius: 8px;
-      background: var(--canvas);
+      gap: 0.7rem;
+      padding: 0.6rem 0;
+      border-top: 1px solid var(--hairline);
     }
-    .os__rowtext {
+    .os__row:first-child {
+      border-top: 0;
+    }
+    .os__rn {
+      flex: none;
+      width: 0.9rem;
+      text-align: right;
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      color: var(--ink-3);
+    }
+    .os__rmain {
+      flex: 1 1 auto;
+      min-width: 0;
       display: flex;
       flex-direction: column;
-      gap: 0.1rem;
+      gap: 0.15rem;
+    }
+    .os__rnamerow {
+      display: flex;
+      align-items: center;
+      gap: 0.45rem;
       min-width: 0;
     }
-    .os__rowtext strong {
-      font-size: 0.82rem;
+    .os__rname {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      font-size: 0.84rem;
       font-weight: 550;
       color: var(--ink);
-    }
-    .os__rowtext > span {
-      font-family: var(--font-mono);
-      font-size: 0.72rem;
-      color: var(--ink-3);
+      text-decoration: underline;
+      text-decoration-color: var(--hairline-2);
+      text-underline-offset: 2px;
+      white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      white-space: nowrap;
     }
-    .os__chip {
+    .os__ext {
+      display: inline-flex;
+      color: var(--ink-3);
+    }
+    .os__ext :global(svg) {
+      width: 11px;
+      height: 11px;
+      display: block;
+    }
+    .os__badge {
       flex: none;
-      font-size: 0.72rem;
-      font-weight: 500;
-      padding: 0.3rem 0.66rem;
-      border-radius: 6px;
-      background: var(--ink);
-      color: var(--surface);
-    }
-    .os__chip--ghost {
-      background: transparent;
+      font-family: var(--font-mono);
+      font-size: 0.62rem;
+      letter-spacing: 0.02em;
       color: var(--ink-2);
+      padding: 0.08rem 0.4rem;
       border: 1px solid var(--hairline-2);
+      border-radius: 999px;
     }
-    .os__more {
+    .os__rdetail {
       font-family: var(--font-mono);
       font-size: 0.7rem;
-      letter-spacing: 0.02em;
       color: var(--ink-3);
-      padding-left: 0.2rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
-    .os__note {
-      font-family: var(--font-mono);
-      font-size: 0.72rem;
-      line-height: 1.4;
+    .os__ractions {
+      flex: none;
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+    }
+    .os__btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      font-family: inherit;
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--ink);
+      background: var(--surface);
+      border: 1px solid var(--hairline-2);
+      border-radius: 8px;
+      padding: 0.32rem 0.66rem;
+      cursor: pointer;
+      transition:
+        background-color 120ms var(--ease-out),
+        border-color 120ms var(--ease-out);
+    }
+    .os__btn:hover {
+      background: var(--hover);
+      border-color: var(--ink-3);
+    }
+    .os__btnplus {
+      font-size: 0.95em;
       color: var(--ink-3);
-      margin: 0.15rem 0 0;
+    }
+    .os__pass {
+      font-size: 0.75rem;
+      color: var(--ink-3);
+    }
+    .os__status {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.3rem;
+      font-size: 0.75rem;
+      color: var(--ink-2);
+      white-space: nowrap;
+    }
+    .os__statustick {
+      color: var(--ink-3);
+    }
+    .os__status--in .os__statustick {
+      color: var(--live);
     }
     .os__foot {
       text-align: center;
@@ -602,8 +690,8 @@ const initial = pillars[start];
       .os__label {
         font-size: 0.625rem;
       }
-      .os__rowtext > span {
-        white-space: normal;
+      .os__rdetail {
+        display: none;
       }
     }
 

--- a/apps/website/src/pages/pa-os.astro
+++ b/apps/website/src/pages/pa-os.astro
@@ -26,9 +26,9 @@ const pillars = [
     link: 'Open mandate',
     note: '4 candidates withheld — no source evidence, so PA-OS won’t present them for approval.',
     rows: [
-      { n: '1', name: 'Rockmont Family Office', detail: '€20M avg check · EU real estate · Helsinki', badge: 'New', state: 'in', status: 'In pipeline', link: 'Open' },
-      { n: '2', name: 'Aldwych Capital Office', detail: '€10–30M · value-add RE · London', badge: 'New', state: 'action', action: 'Add to Meridian', link: 'Pass' },
-      { n: '5', name: 'Talstein Multi-Family Office', detail: '€15M avg · diversified · Zurich', badge: 'New', state: 'passed', status: 'Passed', link: 'Reconsider' },
+      { n: '1', name: 'Rockmont Family Office', detail: '€20M avg check · EU real estate · Helsinki', badge: 'New', ext: true, state: 'in', status: 'In pipeline', link: 'Open' },
+      { n: '2', name: 'Aldwych Capital Office', detail: '€10–30M · value-add RE · London', badge: 'New', ext: true, state: 'action', action: 'Add to Meridian', link: 'Pass' },
+      { n: '5', name: 'Talstein Multi-Family Office', detail: '€15M avg · diversified · Zurich', badge: 'New', ext: true, state: 'passed', status: 'Passed', link: 'Reconsider' },
     ],
   },
   {
@@ -39,9 +39,9 @@ const pillars = [
     link: 'Open mandate',
     note: '2 low-confidence fields — quoted to source, flagged for your review.',
     rows: [
-      { n: '1', name: 'Asset class — Real estate', detail: 'deck p.2 · “private real estate strategies”', badge: 'p.2', state: 'action', action: 'Accept', link: 'Edit' },
-      { n: '2', name: 'Target raise — €40M', detail: 'deck p.4 · “seeking €40 million”', badge: 'p.4', state: 'in', status: 'Accepted', link: 'Open' },
-      { n: '3', name: 'Check size — €5–15M', detail: 'deck p.6 · flagged low confidence', badge: 'p.6', state: 'action', action: 'Accept', link: 'Edit' },
+      { n: '1', name: 'Asset class — Real estate', detail: 'deck p.2 · “private real estate strategies”', badge: 'p.2', ext: false, state: 'action', action: 'Accept', link: 'Edit' },
+      { n: '2', name: 'Target raise — €40M', detail: 'deck p.4 · “seeking €40 million”', badge: 'p.4', ext: false, state: 'in', status: 'Accepted', link: 'Open' },
+      { n: '3', name: 'Check size — €5–15M', detail: 'deck p.6 · flagged low confidence', badge: 'p.6', ext: false, state: 'action', action: 'Accept', link: 'Edit' },
     ],
   },
   {
@@ -52,9 +52,9 @@ const pillars = [
     link: 'Open mandate',
     note: '',
     rows: [
-      { n: '1', name: 'Rockmont Family Office', detail: '94 fit · invests EU RE, €20M ticket', badge: '94', state: 'in', status: 'Shortlisted', link: 'Why' },
-      { n: '2', name: 'Meridian Trust Office', detail: '89 fit · value-add mandate match', badge: '89', state: 'action', action: 'Add to shortlist', link: 'Why' },
-      { n: '3', name: 'Aldwych Capital Office', detail: '85 fit · ticket size match', badge: '85', state: 'action', action: 'Add to shortlist', link: 'Why' },
+      { n: '1', name: 'Rockmont Family Office', detail: '94 fit · invests EU RE, €20M ticket', badge: '94', ext: true, state: 'in', status: 'Shortlisted', link: 'Why' },
+      { n: '2', name: 'Meridian Trust Office', detail: '89 fit · value-add mandate match', badge: '89', ext: true, state: 'action', action: 'Add to shortlist', link: 'Why' },
+      { n: '3', name: 'Aldwych Capital Office', detail: '85 fit · ticket size match', badge: '85', ext: true, state: 'action', action: 'Add to shortlist', link: 'Why' },
     ],
   },
   {
@@ -65,9 +65,9 @@ const pillars = [
     link: 'Open drafts',
     note: 'Nothing sends itself — every draft waits for you to send.',
     rows: [
-      { n: '1', name: 'To: Rockmont Family Office', detail: '“Meridian — EU real estate, €20M ticket…”', badge: 'Draft', state: 'action', action: 'Review draft', link: 'Discard' },
-      { n: '2', name: 'To: Aldwych Capital Office', detail: '“Following up on value-add real estate…”', badge: 'Draft', state: 'action', action: 'Review draft', link: 'Discard' },
-      { n: '3', name: 'To: Meridian Trust Office', detail: '“Introducing the Meridian mandate…”', badge: 'Draft', state: 'action', action: 'Review draft', link: 'Discard' },
+      { n: '1', name: 'To: Rockmont Family Office', detail: '“Meridian — EU real estate, €20M ticket…”', badge: 'Draft', ext: false, state: 'action', action: 'Review draft', link: 'Discard' },
+      { n: '2', name: 'To: Aldwych Capital Office', detail: '“Following up on value-add real estate…”', badge: 'Draft', ext: false, state: 'action', action: 'Review draft', link: 'Discard' },
+      { n: '3', name: 'To: Meridian Trust Office', detail: '“Introducing the Meridian mandate…”', badge: 'Draft', ext: false, state: 'action', action: 'Review draft', link: 'Discard' },
     ],
   },
   {
@@ -78,9 +78,9 @@ const pillars = [
     link: 'Open PDF',
     note: '',
     rows: [
-      { n: '1', name: 'Outreach — 12 emails, 5 meetings, 3 calls', detail: 'each figure traces to a record', badge: '', state: 'action', action: 'Open PDF', link: 'Rebuild' },
-      { n: '2', name: 'Pipeline — €40M across 8 investors', detail: '3 in diligence · 2 committed', badge: '', state: 'in', status: 'In report', link: 'Open' },
-      { n: '3', name: 'Coverage — 60 of 72 mapped', detail: '12 pending review', badge: '', state: 'action', action: 'Open PDF', link: 'Rebuild' },
+      { n: '1', name: 'Outreach — 12 emails, 5 meetings, 3 calls', detail: 'each figure traces to a record', badge: '', ext: false, state: 'action', action: 'Open PDF', link: 'Rebuild' },
+      { n: '2', name: 'Pipeline — €40M across 8 investors', detail: '3 in diligence · 2 committed', badge: '', ext: false, state: 'in', status: 'In report', link: 'Open' },
+      { n: '3', name: 'Coverage — 60 of 72 mapped', detail: '12 pending review', badge: '', ext: false, state: 'action', action: 'Open PDF', link: 'Rebuild' },
     ],
   },
 ];
@@ -147,7 +147,7 @@ const initial = pillars[start];
               <span class="os__rn">{r.n}</span>
               <div class="os__rmain">
                 <div class="os__rnamerow">
-                  <span class="os__rname">{r.name}<span class="os__ext" set:html={extIcon} /></span>
+                  <span class={`os__rname${r.ext ? ' os__rname--link' : ''}`}>{r.name}{r.ext && <span class="os__ext" set:html={extIcon} />}</span>
                   {r.badge && <span class="os__badge">{r.badge}</span>}
                 </div>
                 <div class="os__rdetail">{r.detail}</div>
@@ -211,10 +211,12 @@ const initial = pillars[start];
 
           const main = el('div', 'os__rmain');
           const namerow = el('div', 'os__rnamerow');
-          const name = el('span', 'os__rname', r.name);
-          const ext = el('span', 'os__ext');
-          ext.innerHTML = extIcon;
-          name.append(ext);
+          const name = el('span', 'os__rname' + (r.ext ? ' os__rname--link' : ''), r.name);
+          if (r.ext) {
+            const ext = el('span', 'os__ext');
+            ext.innerHTML = extIcon;
+            name.append(ext);
+          }
           namerow.append(name);
           if (r.badge) namerow.append(el('span', 'os__badge', r.badge));
           main.append(namerow, el('div', 'os__rdetail', r.detail));
@@ -584,12 +586,14 @@ const initial = pillars[start];
       font-size: 0.84rem;
       font-weight: 550;
       color: var(--ink);
-      text-decoration: underline;
-      text-decoration-color: var(--hairline-2);
-      text-underline-offset: 2px;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+    .os__rname--link {
+      text-decoration: underline;
+      text-decoration-color: var(--hairline-2);
+      text-underline-offset: 2px;
     }
     .os__ext {
       display: inline-flex;


### PR DESCRIPTION
Dedicated single-screen landing for cold outreach to placement agents: product-first headline, an all-five-pillars diagram (a pulse walks the rail while a focus tile shows each pillar's cited receipt), one quiet CTA. Reuses the site's design tokens and the homepage pillar copy. Adds /api/og/pa-os.png via the existing @vercel/og pipeline for the shared-link preview card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched a **PA-OS** landing page with an interactive five-step workflow (**Source, Standardize, Match, Campaigns, Report**) including autoplay plus reduced-motion support.
  * Added a branded, on-demand **PA-OS social sharing image**.
* **Updates**
  * Updated **Request access** on the PA-OS page to use the booking URL.
  * Added **PA-OS** to the header navigation and included a “**See PA-OS**” link on the homepage “Product” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->